### PR TITLE
Add babel-helper-is-stateless-component

### DIFF
--- a/packages/babel-helper-is-stateless-component/package.json
+++ b/packages/babel-helper-is-stateless-component/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "babel-helper-is-stateless-component",
+  "version": "0.1.0",
+  "description": "Check whether or not the node is a stateless functionnal component",
+  "main": "lib/index.js",
+  "license": "MIT",
+  "author": "Olivier Tassinari <olivier.tassinari@gmail.com>",
+  "homepage": "https://github.com/thejamekyle/babel-preset-react-optimize#readme",
+  "repository": "https://github.com/thejamekyle/babel-preset-react-optimize/tree/master/packages/babel-helper-is-stateless-component",
+  "bugs": "https://github.com/thejamekyle/babel-preset-react-optimize/issues",
+  "keywords": [
+    "babel-plugin",
+    "react",
+    "stateless",
+    "component"
+  ],
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/babel-helper-is-stateless-component/src/index.js
+++ b/packages/babel-helper-is-stateless-component/src/index.js
@@ -1,0 +1,80 @@
+function isJSXElementOrReactCreateElement(node) {
+  if (node.type === 'JSXElement') {
+    return true;
+  }
+
+  if (node.callee && node.callee.object.name === 'React' && node.callee.property.name === 'createElement') {
+    return true;
+  }
+
+  return false;
+}
+
+function isReturningJSXElement(path) {
+  /**
+   * Early exit for ArrowFunctionExpressions, there is no ReturnStatement node.
+   */
+  if (path.node.init && path.node.init.body && isJSXElementOrReactCreateElement(path.node.init.body)) {
+    return true;
+  }
+
+  let visited = false;
+
+  path.traverse({
+    ReturnStatement(path2) {
+      // We have already found what we are looking for.
+      if (visited) {
+        return;
+      }
+
+      const argument = path2.get('argument');
+
+      // Nothing is returned
+      if (!argument.node) {
+        return;
+      }
+
+      if (isJSXElementOrReactCreateElement(argument.node)) {
+        visited = true;
+        return;
+      }
+
+      if (argument.node.type === 'CallExpression') {
+        const name = argument.get('callee').node.name;
+        const binding = path.scope.getBinding(name);
+
+        if (!binding) {
+          return;
+        }
+
+        if (isReturningJSXElement(binding.path)) {
+          visited = true;
+        }
+      }
+    },
+  });
+
+  return visited;
+}
+
+const validPossibleStatelessComponentTypes = [
+  'VariableDeclarator',
+  'FunctionDeclaration',
+];
+
+/**
+ * Returns `true` if the path represents a function which returns a JSXElement
+ */
+export default function isStatelessComponent(path) {
+  const node = path.node;
+
+  if (validPossibleStatelessComponentTypes.indexOf(node.type) === -1) {
+    return false;
+  }
+
+  if (isReturningJSXElement(path)) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
This helper is coming from [this repository](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types/blob/master/src/isStatelessComponent.js`).
I'm not sure about the API. It takes a `path` as a first and single argument.

@thejameskyle Should this be a `node`? But then, we need `path.traverse`.

Once the API is settled I can add some test.
