### PR TITLE
Add a failing test

### DIFF
--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/impure-static-props/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/impure-static-props/actual.js
@@ -1,4 +1,4 @@
-class Foo extends React.Component {
+class Foo extends Component {
   static bar = 'bar';
 
   render() {


### PR DESCRIPTION
This is a failing test to highlight how we could improve `isReactClass`.
There is what I'm using https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types/blob/master/src/index.js#L3.
I also support one level of class inheritance. But that's not always needed nor wanted.
