### PR TITLE
.babelrc: remove duplicate presets from production

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ $ npm install --save-dev babel-preset-react-optimize
   "presets": ["es2015", "react"],
   "env": {
     "production": {
-      "presets": ["es2015", "react", "react-optimize"]
+      "presets": ["react-optimize"]
     }
   }
 }


### PR DESCRIPTION
Remove presets that were already defined in the base configuration.
