### PR TITLE
Add babel-plugin-transform-react-router-optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,29 @@ MyComponent.propTypes = {
 };
 ```
 
+### [`transform-react-router-optimize`](https://github.com/nerdlabs/babel-plugin-transform-react-router-optimize)
+
+The [react-router](https://github.com/reactjs/react-router) guides mention a
+technique to reduce bundle size by only including neccessary parts of the
+react-router lib.
+
+[Read the guide here](https://github.com/reactjs/react-router/blob/master/docs/guides/MinimizingBundleSize.md).
+
+This plugin will do the transformation automatically for you.
+
+**Input:**
+```js
+import { Link, Route, Router } from 'react-router'
+```
+
+**Output:**
+
+```js
+import Link from 'react-router/lib/Link'
+import Route from 'react-router/lib/Route'
+import Router from 'react-router/lib/Router'
+```
+
 ## Install
 
 ```sh

--- a/packages/babel-preset-react-optimize/package.json
+++ b/packages/babel-preset-react-optimize/package.json
@@ -16,8 +16,9 @@
   "dependencies": {
     "babel-plugin-transform-react-constant-elements": "^6.5.0",
     "babel-plugin-transform-react-inline-elements": "^6.6.5",
+    "babel-plugin-transform-react-pure-class-to-function": "^1.0.1",
     "babel-plugin-transform-react-remove-prop-types": "^0.2.5",
-    "babel-plugin-transform-react-pure-class-to-function": "^1.0.1"
+    "babel-plugin-transform-react-router-optimize": "^1.0.1"
   },
   "devDependencies": {}
 }

--- a/packages/babel-preset-react-optimize/src/index.js
+++ b/packages/babel-preset-react-optimize/src/index.js
@@ -3,6 +3,7 @@ module.exports = {
     require('babel-plugin-transform-react-constant-elements'),
     require('babel-plugin-transform-react-inline-elements'),
     require('babel-plugin-transform-react-remove-prop-types')['default'],
-    require('babel-plugin-transform-react-pure-class-to-function')
+    require('babel-plugin-transform-react-pure-class-to-function'),
+    require('babel-plugin-transform-react-router-optimize')['default']
   ]
 };


### PR DESCRIPTION
This transform will help to reduce file size in projects which use the
react-router.

The react-router guides mention how to import only neccessary parts of
the library to keep the bundle size small:
https://github.com/reactjs/react-router/blob/master/docs/guides/MinimizingBundleSize.md

This babel plugin will do the transformation automatically.
