### PR TITLE
Added support for ES6 imports and exports (and PureComponent)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/babel-helper-is-react-class/package.json
+++ b/packages/babel-helper-is-react-class/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-helper-is-react-class",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "",
   "main": "lib/index.js",
   "license": "MIT",

--- a/packages/babel-helper-is-react-class/src/index.js
+++ b/packages/babel-helper-is-react-class/src/index.js
@@ -1,10 +1,44 @@
 module.exports = function(t) {
-  return function isReactClass(node) {
-    const superClass = node.superClass;
-    return (
+  return function isReactClass(path) {
+    const superClass = path.node.superClass;
+
+    const isDirectReactClass = (
       t.isMemberExpression(superClass) &&
       t.isIdentifier(superClass.object, { name: 'React' }) &&
-      t.isIdentifier(superClass.property, { name: 'Component' })
+      (
+        t.isIdentifier(superClass.property, { name: 'Component' }) ||
+        t.isIdentifier(superClass.property, { name: 'PureComponent' })
+      )
     );
+
+    if (isDirectReactClass) { return true; }
+
+    const state = {
+      localComponentNames: []
+    };
+    const importVisitor = {
+      ImportDeclaration(nestedPath) {
+        const node = nestedPath.node;
+
+        if (t.isStringLiteral(node.source, { value: 'react' })) {
+          this.localComponentNames = node.specifiers
+            .filter(specifier => (
+              t.isImportSpecifier(specifier) &&
+              (
+                specifier.imported.name === 'Component' ||
+                specifier.imported.name === 'PureComponent'
+              )
+            ))
+            .map(specifier => specifier.local.name);
+        }
+      }
+    };
+
+    // Check for imports as local variable names
+    path.findParent(p => t.isProgram(p)).traverse(importVisitor, state);
+    if (state.localComponentNames.length === 0) {
+      return false;
+    }
+    return state.localComponentNames.indexOf(superClass.name) !== -1;
   };
 }

--- a/packages/babel-plugin-transform-react-pure-class-to-function/package.json
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-react-pure-class-to-function",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "",
   "main": "lib/index.js",
   "license": "MIT",
@@ -14,7 +14,7 @@
     "optimize"
   ],
   "dependencies": {
-    "babel-helper-is-react-class": "^1.0.0"
+    "babel-helper-is-react-class": "^2.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.7.6",

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/export-default/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/export-default/actual.js
@@ -1,4 +1,4 @@
-module.exports = class Foo extends React.Component {
+export default class Foo extends React.Component {
   static propTypes = {
     foo: React.PropTypes.string.isRequired
   };
@@ -7,4 +7,4 @@ module.exports = class Foo extends React.Component {
     this.props.foo;
     return <div />;
   }
-};
+}

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/export-default/expected.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/export-default/expected.js
@@ -1,0 +1,7 @@
+export default function Foo(props) {
+  props.foo;
+  return <div />;
+}
+Foo.propTypes = {
+  foo: React.PropTypes.string.isRequired
+};

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/export-named/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/export-named/actual.js
@@ -1,4 +1,4 @@
-module.exports = class Foo extends React.Component {
+export class Foo extends React.Component {
   static propTypes = {
     foo: React.PropTypes.string.isRequired
   };
@@ -7,4 +7,4 @@ module.exports = class Foo extends React.Component {
     this.props.foo;
     return <div />;
   }
-};
+}

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/export-named/expected.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/export-named/expected.js
@@ -1,0 +1,7 @@
+export function Foo(props) {
+  props.foo;
+  return <div />;
+}
+Foo.propTypes = {
+  foo: React.PropTypes.string.isRequired
+};

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/imported-and-export-default/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/imported-and-export-default/actual.js
@@ -1,0 +1,16 @@
+import React, { Component, PropTypes } from 'react';
+
+export default class Foo extends Component {
+  static propTypes = {
+    foo: PropTypes.string.isRequired
+  }
+
+  static defaultProps = {
+    foo: 'bar'
+  }
+
+  render() {
+    this.props.foo;
+    return <div />;
+  }
+}

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/imported-and-export-default/expected.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/imported-and-export-default/expected.js
@@ -1,0 +1,12 @@
+import React, { Component, PropTypes } from 'react';
+
+export default function Foo(props) {
+  props.foo;
+  return <div />;
+}
+Foo.propTypes = {
+  foo: PropTypes.string.isRequired
+};
+Foo.defaultProps = {
+  foo: 'bar'
+};

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/imported-component-renamed/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/imported-component-renamed/actual.js
@@ -1,0 +1,12 @@
+import React, { Component as Comp, PropTypes } from 'react';
+
+module.exports = class Foo extends Comp {
+  static propTypes = {
+    foo: PropTypes.string.isRequired
+  };
+
+  render() {
+    this.props.foo;
+    return <div />;
+  }
+};

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/imported-component-renamed/expected.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/imported-component-renamed/expected.js
@@ -1,0 +1,13 @@
+import React, { Component as Comp, PropTypes } from 'react';
+
+module.exports = function () {
+  function Foo(props) {
+    props.foo;
+    return <div />;
+  }
+
+  Foo.propTypes = {
+    foo: PropTypes.string.isRequired
+  };
+  return Foo;
+}();

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/imported-component/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/imported-component/actual.js
@@ -1,0 +1,12 @@
+import React, { Component, PropTypes } from 'react';
+
+module.exports = class Foo extends Component {
+  static propTypes = {
+    foo: PropTypes.string.isRequired
+  };
+
+  render() {
+    this.props.foo;
+    return <div />;
+  }
+};

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/imported-component/expected.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/imported-component/expected.js
@@ -1,0 +1,13 @@
+import React, { Component, PropTypes } from 'react';
+
+module.exports = function () {
+  function Foo(props) {
+    props.foo;
+    return <div />;
+  }
+
+  Foo.propTypes = {
+    foo: PropTypes.string.isRequired
+  };
+  return Foo;
+}();

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/impure-instance-props/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/impure-instance-props/actual.js
@@ -3,6 +3,6 @@ class Foo extends React.Component {
 
   render() {
     this.props.foo;
-    return <div/>;
+    return <div />;
   }
 }

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/impure-methods/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/impure-methods/actual.js
@@ -5,6 +5,6 @@ class Foo extends React.Component {
 
   render() {
     this.props.foo;
-    return <div/>;
+    return <div />;
   }
 }

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/impure-ref/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/impure-ref/actual.js
@@ -1,6 +1,6 @@
 class Foo extends React.Component {
   render() {
     this.props.foo;
-    return <div ref="foo"/>;
+    return <div ref="foo" />;
   }
 }

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/impure-state/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/impure-state/actual.js
@@ -1,6 +1,6 @@
 class Foo extends React.Component {
   render() {
     this.props.foo;
-    return <div className={this.state.className}/>;
+    return <div className={this.state.className} />;
   }
 }

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/impure-static-props/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/impure-static-props/actual.js
@@ -3,6 +3,6 @@ class Foo extends React.Component {
 
   render() {
     this.props.foo;
-    return <div/>;
+    return <div />;
   }
 }

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/not-a-react-component/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/not-a-react-component/actual.js
@@ -1,0 +1,16 @@
+import React, { PropTypes } from 'react';
+
+class Component {
+  // A big faker!
+}
+
+module.exports = class Foo extends Component {
+  static propTypes = {
+    foo: PropTypes.string.isRequired
+  };
+
+  render() {
+    this.props.foo;
+    return <div />;
+  }
+};

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/not-a-react-component/expected.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/not-a-react-component/expected.js
@@ -1,0 +1,16 @@
+import React, { PropTypes } from 'react';
+
+class Component {
+  // A big faker!
+}
+
+module.exports = class Foo extends Component {
+  static propTypes = {
+    foo: PropTypes.string.isRequired
+  };
+
+  render() {
+    this.props.foo;
+    return <div />;
+  }
+};

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/pure-component/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/pure-component/actual.js
@@ -1,4 +1,4 @@
-module.exports = class Foo extends React.Component {
+module.exports = class Foo extends React.PureComponent {
   static propTypes = {
     foo: React.PropTypes.string.isRequired
   };

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/pure-component/expected.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/pure-component/expected.js
@@ -1,0 +1,11 @@
+module.exports = function () {
+  function Foo(props) {
+    props.foo;
+    return <div />;
+  }
+
+  Foo.propTypes = {
+    foo: React.PropTypes.string.isRequired
+  };
+  return Foo;
+}();

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/pure-no-props/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/pure-no-props/actual.js
@@ -1,6 +1,6 @@
 class Foo extends React.Component {
   render() {
     this.props.foo;
-    return <div/>;
+    return <div />;
   }
 }

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/pure-props/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/pure-props/actual.js
@@ -1,5 +1,5 @@
 class Foo extends React.Component {
   render() {
-    return <div className={this.props.className}/>;
+    return <div className={this.props.className} />;
   }
 }

--- a/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/pure-static-props/actual.js
+++ b/packages/babel-plugin-transform-react-pure-class-to-function/test/fixtures/pure-static-props/actual.js
@@ -8,6 +8,6 @@ class Foo extends React.Component {
   };
 
   render() {
-    return <div className={this.props.className}/>;
+    return <div className={this.props.className} />;
   }
 }


### PR DESCRIPTION
Fixes #23 & #8 by checking imports for `import React, { Component } from 'react'`, and also adds support for the new `PureComponent`.

It possibly also fixes #22 due to the fix for export declarations (which are mostly only used in the tests, since Babel already converts the ES6 exports down to ES5 syntax).

- Updated `babel-helper-is-react-class`
    - Version bump to `2.0.0` because of the API change (requires `path` instead of `path.node`)
    - Added a traversal for named imports (e.g. `import React, { Component } from 'react'`)
    - Added checks for `PureComponent`
- Updated `babel-plugin-transform-react-pure-class-to-function`
    - Refactored replacement logic to read more clearly now that there's 3 code paths
    - Added export declaration check, to avoid "We don't know what to do with this node type" errors
    - Added extra tests for new functionality