### PR TITLE
Put constant-elements plugin last

### DIFF
--- a/packages/babel-preset-react-optimize/src/index.js
+++ b/packages/babel-preset-react-optimize/src/index.js
@@ -1,8 +1,8 @@
 module.exports = {
   plugins: [
-    require('babel-plugin-transform-react-constant-elements'),
     require('babel-plugin-transform-react-inline-elements'),
     require('babel-plugin-transform-react-remove-prop-types')['default'],
-    require('babel-plugin-transform-react-pure-class-to-function')
+    require('babel-plugin-transform-react-pure-class-to-function'),
+    require('babel-plugin-transform-react-constant-elements')
   ]
 };


### PR DESCRIPTION
see https://github.com/babel/babel/issues/5325#issuecomment-292064058

There's a bug some of us have with this plugin, and it seems to disappear (or at least on some codebases) when this plugin is declared last in the list.

